### PR TITLE
Allow Markdown to be loaded from import/export

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,20 @@ const html = "<h1>hello</h1><p><strong>This is markdown</strong></p>"
 
 ### External files
 
+Using CommonJS:
+
 ```js
 const html = markdown.require('./foo.md')
+
+// yield:
+
+const html = '<h1>foo</h1>'
+```
+
+Using ESM:
+
+```js
+import html from './foo.md'
 
 // yield:
 


### PR DESCRIPTION
Great module! Noticed it only works with `require` ATM, so this PR extends the AST traversal to catch Markdown imported and exported using ESM.